### PR TITLE
Add more meaningful tests to match for url regex

### DIFF
--- a/static/regexdata.json
+++ b/static/regexdata.json
@@ -255,7 +255,13 @@
             "abcde",
             "john doe",
             "johnny",
-            "abcdefghijklmnopqrst"
+            "abcdefghijklmnopqrst",
+            "https://github.com/Huy-Ngo/i-hate-regex",
+            "https://www.facebook.com/",
+            "https://www.google.com/",
+            "https://xkcd.com/2048/",
+            "https://this-shouldn't.match@example.com",
+            "http://www.example.com/"
         ],
         "cheatRegex": [
             "/^/",


### PR DESCRIPTION
The current tests were:

```
lorem
ipsum
gr3at
a
ab
abc
abcd
abcde
john doe
johnny
abcdefghijklmnopqrst
```

I find these unhelpful because none of them are valid urls.