### PR TITLE
meta: Added GitHub sponsor button config

### DIFF
--- a/.github/workflows/FUNDING.yml
+++ b/.github/workflows/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: ihateregex


### PR DESCRIPTION
Leverage the GitHub sponsor button to make people aware about the various ways in which one can support the development.