### PR TITLE
Updated hyphen word break

### DIFF
--- a/static/regex/data.json
+++ b/static/regex/data.json
@@ -477,7 +477,7 @@
         "title": "hyphen word break",
         "tagline": "match the end of line hyphens that split up words",
         "description": "A hyphen appears at the end of a line when the word must be split to fit on the line",
-        "regex": "[a-zA-Z][\\-]$[\\n][a-zA-Z]",
+        "regex": "(?<=[a-z])-$\\n(?=[a-z])",
         "flag": "gm",
         "matchText": [
             "It illustrates not only the impor-",
@@ -487,8 +487,11 @@
             "ing the meaning of questions and answers. Our colleague had"
         ],
         "cheatRegex": [
-            "/[a-zA-Z]/",
-            "/$/"
+            "/[a-z]/",
+            "/(?<=[aeiou])\\w/",
+            "/$/",
+            "/z(?=a)/",
+
         ],
         "embedHeight": 300,
         "tags" : ["hyphen", "word_break"]

--- a/static/regex/markdown/hyphen-word-break.md
+++ b/static/regex/markdown/hyphen-word-break.md
@@ -1,3 +1,9 @@
 A hyphen word break is when a word is broken into 2 using a hyphen (`-`) to be continued in the next line
 
-This is especially useful in scraping data when you wanna join hyphen seperated words
+This is especially useful in scraping data when you wanna join hyphen separated words
+
+The first part of the statement finds lowercase letters (since this should be in the middle of a word) but excludes it from the final selection
+
+the middle part of the statement finds a hyphen and NewLine character that is at the end of a line
+
+the last part looks for a lowercase letter on the new line (again the middle of a sentence so it should be lowercase)


### PR DESCRIPTION
Now it matches only the hyphen and the newline character

It still looks for lowercase letters before and after the hyphen and newline

(I intentionally do only lowercase because the letters both preceding and following a hyphen in a word break should be lowercase)