### PR TITLE
add credit cards regex pattern

### DIFF
--- a/static/regex/data.json
+++ b/static/regex/data.json
@@ -533,5 +533,26 @@
         "cheatRegex": [],
         "embedHeight": 315,
         "tags" : ["emoji", "emoticon", "smiley"]
+    },
+    {
+        "id": "credit-card",
+        "title": "credit card number",
+        "tagline": "match if the string is a credit card",
+        "description": "Support Visa (group #1), MasterCard (group #2), American Express (group #3), Diners Club (group #4), Discover (group #5) and JCB (group #6). More info can be found here: https://www.regular-expressions.info/creditcard.html",
+        "regex": "(^4[0-9]{12}(?:[0-9]{3})?$)|(^(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$)|(3[47][0-9]{13})|(^3(?:0[0-5]|[68][0-9])[0-9]{11}$)|(^6(?:011|5[0-9]{2})[0-9]{12}$)|(^(?:2131|1800|35\\d{3})\\d{11}$)",
+        "flag": "gm",
+        "matchText": [
+            "4569403961014710",
+            "5191914942157165",
+            "370341378581367",
+            "38520000023237",
+            "6011000000000000",
+            "3566002020360505",
+            "1234566660000222"
+        ],
+        "cheatRegex": [
+        ],
+        "embedHeight": 1100,
+        "tags" : ["credit card", "Visa", "MasterCard", "American Express", "Diners Club", "Discover", "JCB"]
     }
 ]

--- a/static/regex/data.json
+++ b/static/regex/data.json
@@ -538,7 +538,7 @@
         "id": "credit-card",
         "title": "credit card number",
         "tagline": "match if the string is a credit card",
-        "description": "Support Visa (group #1), MasterCard (group #2), American Express (group #3), Diners Club (group #4), Discover (group #5) and JCB (group #6). More info can be found here: https://www.regular-expressions.info/creditcard.html",
+        "description": "Credit card number is the card unique identifier found on payment cards.",
         "regex": "(^4[0-9]{12}(?:[0-9]{3})?$)|(^(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$)|(3[47][0-9]{13})|(^3(?:0[0-5]|[68][0-9])[0-9]{11}$)|(^6(?:011|5[0-9]{2})[0-9]{12}$)|(^(?:2131|1800|35\\d{3})\\d{11}$)",
         "flag": "gm",
         "matchText": [
@@ -553,6 +553,6 @@
         "cheatRegex": [
         ],
         "embedHeight": 1100,
-        "tags" : ["credit card", "Visa", "MasterCard", "American Express", "Diners Club", "Discover", "JCB"]
+        "tags" : ["credit card", "payment card", "Visa", "MasterCard", "American Express", "Diners Club", "Discover", "JCB"]
     }
 ]

--- a/static/regex/markdown/credit-card.md
+++ b/static/regex/markdown/credit-card.md
@@ -1,0 +1,1 @@
+This expression can be used to detect or verify credit card numbers (Visa, MasterCard, American Express, Diners Club, Discover and JCB).

--- a/static/regex/markdown/credit-card.md
+++ b/static/regex/markdown/credit-card.md
@@ -1,1 +1,10 @@
-This expression can be used to detect or verify credit card numbers (Visa, MasterCard, American Express, Diners Club, Discover and JCB).
+This expression can be used to detect or verify credit card numbers:  
+- Visa (group #1)  
+- MasterCard (group #2)  
+- American Express (group #3)  
+- Diners Club (group #4)  
+- Discover (group #5)  
+- JCB (group #6)  
+Disclaimer:  
+If you want to use regex just to know the card brand for visual use (display Visa logo or label), that is fine.  
+But if your code logic depends on it, then don't use regex, and don't use 3rd party plugin/library instead (read more about it [here](https://stackoverflow.com/questions/9315647/regex-credit-card-number-tests/55019607#55019607)).


### PR DESCRIPTION
Support Visa, MasterCard, American Express, Diners Club, Discover and JCB. 
Created and tested based on the patterns from here: https://www.regular-expressions.info/creditcard.html