### PR TITLE
url pattern: fix mega links aren't matched

### DIFF
--- a/static/regex/data.json
+++ b/static/regex/data.json
@@ -232,7 +232,7 @@
         "title": "url",
         "tagline": "match a valid url",
         "description": "A valid URL with http/https",
-        "regex": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&\\/\\/=]*)",
+        "regex": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()!@:%_\\+.~#?&\\/\\/=]*)",
         "flag": "gm",
         "matchText": [
             "abcdef",


### PR DESCRIPTION
MEGA.nz decrypted links have "!" char, like https://mega.nz/#!DDx2DQTa!E0_ck27otWgU1Sbh5zosw2zaWX9W9MoClSWmUAwQNmQ