### PR TITLE
chore: update lint-staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,7 @@
     }
   },
   "lint-staged": {
-    "*{.js,.vue}": [
-      "eslint --fix",
-      "git add"
-    ]
+    "*{.js,.vue}": "eslint --fix"
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.9.5",


### PR DESCRIPTION
Since `v10` `lint-staged` automatically adds modified files to the `git commit index`.