### PR TITLE
fix: allow longer top-level-domains

### DIFF
--- a/static/regex/data.json
+++ b/static/regex/data.json
@@ -232,7 +232,7 @@
         "title": "url",
         "tagline": "match a valid url",
         "description": "A valid URL with http/https",
-        "regex": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()!@:%_\\+.~#?&\\/\\/=]*)",
+        "regex": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,7}\\b([-a-zA-Z0-9()!@:%_\\+.~#?&\\/\\/=]*)",
         "flag": "gm",
         "matchText": [
             "abcdef",


### PR DESCRIPTION
I noticed that our company's top-level-domain (.schwarz) could not be matched with this RegEx. 
Suggesting to extend the length to 7 characters. 

Thanks!