### PR TITLE
Increases TLD max length of URL regex

### DIFF
--- a/static/regex/data.json
+++ b/static/regex/data.json
@@ -232,7 +232,7 @@
         "title": "url",
         "tagline": "match a valid url",
         "description": "A valid URL with http/https",
-        "regex": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()!@:%_\\+.~#?&\\/\\/=]*)",
+        "regex": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,63}\\b([-a-zA-Z0-9()!@:%_\\+.~#?&\\/\\/=]*)",
         "flag": "gm",
         "matchText": [
             "abcdef",


### PR DESCRIPTION
According to [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_domain_name#:~:text=A%20TLD%27s%20maximum%20length%20is%2063%20characters):
> A TLD's maximum length is 63 characters

This PR, modifies the regex accordingly.

This may close and replace PR #105 